### PR TITLE
assertElementTextEquals

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -781,6 +781,18 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
     }
 
     /**
+     * Asserts that an element's text equals to given string.
+     *
+     * @param  string $locator
+     * @param  string $text
+     * @param  string $message
+     */
+    public function assertElementTextEquals($locator, $text, $message = '')
+    {
+        $this->assertEquals($text, $this->getText($locator), $message);
+    }
+
+    /**
      * Asserts that a select element has a specific option.
      *
      * @param  string $selectLocator


### PR DESCRIPTION
I propose to add assertion to perform strict comparison of element's text with the given string.  If necessary I can also add a counterpart for this assertion, assertElementTextNotEquals.
