### PR TITLE
set PHPUNIT_COVERAGE_DATA_DIRECTORY from outside

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -943,7 +943,12 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
             $buffer = @file_get_contents($url);
 
             if ($buffer !== FALSE) {
-                return $this->matchLocalAndRemotePaths(unserialize($buffer));
+                $coverageData = unserialize($buffer);
+                if (is_array($coverageData)) {
+                    return $this->matchLocalAndRemotePaths($coverageData);
+                } else {
+                    throw new Exception('Empty or invalid code coverage data received from url "' . $url . '"');
+                }
             }
         }
 

--- a/PHPUnit/Extensions/SeleniumTestCase/phpunit_coverage.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/phpunit_coverage.php
@@ -48,7 +48,9 @@ require_once 'PHP/CodeCoverage/Filter.php';
 // Set this to the directory that contains the code coverage files.
 // It defaults to getcwd(). If you have configured a different directory
 // in prepend.php, you need to configure the same directory here.
-$GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'] = getcwd();
+if (!isset($GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'])) {
+    $GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'] = getcwd();
+}
 
 if (isset($_GET['PHPUNIT_SELENIUM_TEST_ID'])) {
     $files = File_Iterator_Factory::getFileIterator(

--- a/PHPUnit/Extensions/SeleniumTestCase/prepend.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/prepend.php
@@ -48,7 +48,9 @@
 // If you change the default setting, please make sure to also configure
 // the same directory in phpunit_coverage.php. Also note that the webserver
 // needs write access to the directory.
-$GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'] = FALSE;
+if (!isset($GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'])) {
+    $GLOBALS['PHPUNIT_COVERAGE_DATA_DIRECTORY'] = FALSE;
+}
 
 if ( isset($_COOKIE['PHPUNIT_SELENIUM_TEST_ID']) &&
     !isset($_GET['PHPUNIT_SELENIUM_TEST_ID']) &&


### PR DESCRIPTION
I think it is very useful if it's possible to set PHPUNIT_COVERAGE_DATA_DIRECTORY from outside.
I'd love to see this change in the next releases of phpunit-selenium.
Thanks! cebe
