### PR TITLE
Don't report error responses from the Selenium RC server as connection errors

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -885,7 +885,8 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
         $context = stream_context_create(
           array(
             'http' => array(
-              'timeout' => $this->httpTimeout
+              'timeout' => $this->httpTimeout,
+              'ignore_errors' => true
             )
           )
         );


### PR DESCRIPTION
Because PHP's fopen doesn't distinguish between connection errors and HTTP errors, HTTP error responses from the Selenium RC server were throwing an exception with the incorrect message 'Could not connect to the Selenium RC server.'  

This change causes fopen to ignore HTTP error response codes, so that fopen errors always indicate connection problems.  Response bodies that don't begin with the Selenium server's typical "OK" response will generate a more accurate and useful exception which contains the response body from the server.
