### PR TITLE
Support using Selenium Driver interactively from phpsh.

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -159,9 +159,17 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
         }
 
         if (!isset($this->sessionId)) {
+            $session_params = array($this->browser, $this->browserUrl);
+
+            // Hack around google chrome security
+            if ($this->browser == '*googlechrome') {
+                $session_params[] = '';
+                $session_params[] = 'commandLineFlags=--disable-web-security';
+            }
+
             $this->sessionId = $this->getString(
               'getNewBrowserSession',
-              array($this->browser, $this->browserUrl)
+              $session_params
             );
 
             $this->doCommand('setTimeout', array($this->seleniumTimeout * 1000));


### PR DESCRIPTION
this allows me to interactively drive the browser from phpsh (http://www.phpsh.org/), like so:

require_once 'PHPUnit/Autoload.php';
$driver = new PHPUnit_Extensions_SeleniumTestCase_Driver();
$driver->setBrowser('*firefox');
$driver->setBrowserUrl('http://www.facebook.com');
$driver->setHost('localhost');
$driver->setPort(4444);
$driver->setTimeout(30);
$driver->setHttpTimeout(45);
$driver->start();
$driver->open('http://www.google.com');

by simply not requiring that there be a testCase when running the driver...
