### PR TITLE
Fixed assertions on non-target commands (#13)

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -1170,7 +1170,7 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
                     $requiresTarget = (strlen($matches[3][$methodKey]) > 0);
 
                     if (preg_match('/^(.*)Present$/', $baseName, $methodMatches)) {
-                        $notBaseName = $matches[1].'NotPresent';
+                        $notBaseName = $methodMatches[1].'NotPresent';
                     } else {
                         $notBaseName = 'Not'.$baseName;
                     }


### PR DESCRIPTION
Commands that doesnt have target (getTitle, getHtmlSource, etc) always passed through assert condition.

In assertCommand method it always evaluated $expected value from second param of selenium command.

For example this command:
'verifyTitle'
'My Title'
''
produced $expected == '' and regexp '//'. Because of this, regexp+title always asserted true.

Now methods get_/is_ have target params in their phpdoc, so assertCommand can check whether to use
first or second param of selenese command as expected value.
