### PR TITLE
Fixes for issue #66 and #67

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -1074,7 +1074,17 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
                 $buffer .= "\n" . $message;
             }
 
-            $e->setCustomMessage($buffer);
+            // ?: Does the setCustomMessage method exist on the exception object? (fixes issue #67)
+            if(method_exists($e, 'setCustomMessage')) {
+                // -> Method setCustomMessage does exist on the object, this means we are using PHPUnit 
+                //    between 3.4 and 3.6
+                $e->setCustomMessage($buffer);
+            }
+            else {
+                // -> Method setCustomerMessages does not exist on the object, must make a new exception to 
+                //    add the new message (inc. current URL, screenshot path, etc)
+            	$e = new PHPUnit_Framework_ExpectationFailedException($buffer, $e->getComparisonFailure());
+            }
         }
 
         throw $e;


### PR DESCRIPTION
I've made two fixes. One for #66 and one for #67. 
#66 is an error that appear when "comparison failure" is NULL (not set). #67 relates to a change in PHPUnit 3.6 where a few method where removed.
#66 is mentioned here on StackOverflow:

http://stackoverflow.com/questions/7950344/phpunit-selenium-basic-test-fails-with-fatal-error
#67 is a result of the following commit on PHPUnit:

https://github.com/sebastianbergmann/phpunit/commit/7b37221b785dd5aeda8794e8ffdcbfd8cf3aad7b#PHPUnit/Framework/ExpectationFailedException.php
