### PR TITLE
Fix Screenshot Path

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -1044,7 +1044,7 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
                 !empty($this->screenshotPath) &&
                 !empty($this->screenshotUrl)) {
                 $this->drivers[0]->captureEntirePageScreenshot(
-                  $this->screenshotPath . $this->testId .
+                  $this->getScreenshotPath() . $this->testId .
                   '.png'
                 );
 
@@ -1069,5 +1069,21 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
         }
 
         throw $e;
+    }
+
+    /**
+     * Returns correct path to screenshot save path.
+     *
+     * @return string
+     */
+    protected function getScreenshotPath()
+    {
+        $path = $this->screenshotPath;
+
+        if(!in_array(substr($path, strlen($path) -1, 1), array("/","\\"))) {
+            $path .= DIRECTORY_SEPARATOR;
+        }
+
+        return $path;
     }
 }

--- a/Tests/SeleniumTestCaseTest.php
+++ b/Tests/SeleniumTestCaseTest.php
@@ -658,4 +658,27 @@ class Extensions_SeleniumTestCaseTest extends PHPUnit_Extensions_SeleniumTestCas
         $this->store('Dummy Page', 'titleText');
         $this->assertTitle('${titleText}');
     }
+
+    /**
+     * @dataProvider providedScreenshotPaths
+     *
+     * @param string $path
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testGetScreenshotPath($path, $expected)
+    {
+        $this->screenshotPath = $path;
+        $this->assertEquals($expected, $this->getScreenshotPath());
+    }
+
+    public function providedScreenshotPaths()
+    {
+        return array(
+            'C:\screenshots\\' => array('C:\screenshots\\', 'C:\screenshots\\'),
+            '/var/screenshots/' => array('/var/screenshots/', '/var/screenshots/'),
+            '/var/screenshots' => array('/var/screenshots', '/var/screenshots/'),
+        );
+    }
 }


### PR DESCRIPTION
If operating systems are different selenium is unable to create a screennshot. In case of Windows the path should

C:\screenshots\filename.png instead of
 C:\screenshots/\filename.png
