### PR TITLE
small fix for function doCommand()

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -959,7 +959,7 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
 
         curl_close($curl);
 
-        if (strstr($response, 'ERROR: ') == $response) {
+        if (!preg_match('/^OK/', $response)) {
             throw new RuntimeException("Invalid response while accessing the Selenium Server at '$url': " . $response);
         }
 


### PR DESCRIPTION
fix problem with error messages:
"ERROR Server Exception: sessionId should not be null; has this session been started yet?"
or
"Failed to start new browser session: Browser not supported:"
