### PR TITLE
small fix for prepareTestSession() function

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -620,10 +620,6 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
      */
     protected function prepareTestSession()
     {
-        $testCaseClass = get_class($this);
-        if ($testCaseClass::$browsers) {
-            return $this->start();
-        }
         if (self::$shareSession && self::$sessionId !== NULL) {
             $this->setSessionId(self::$sessionId);
             $this->selectWindow('null');


### PR DESCRIPTION
shareSession did not work

test example:

class test extends PHPUnit_Extensions_SeleniumTestCase
{
    protected function setUp()
    {
        $this->setBrowser('*firefox');
        $this->setBrowserUrl("http://google.com");
        $this->shareSession($this->prepareTestSession());
    }

```
/**
 * @test
 */
public function test1()
{
    $this->open('/');
    $this->assertSame('Google', $this->getTitle());
}

/**
 * @test
 */
public function test2()
{
    $this->assertSame('Google', $this->getTitle());
}
```

}
