### PR TITLE
Add selenese test case

### DIFF
--- a/SeleneseTest.php
+++ b/SeleneseTest.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'PHPUnit/Extensions/SeleniumTestCase.php';
+
+class SeleneseTest extends PHPUnit_Extensions_SeleniumTestCase
+{
+    public static $seleneseDirectory = './selenium-1-tests/selenese/';
+    
+    protected function setUp()
+    {
+        $this->setBrowser('*firefox');
+        $this->setBrowserUrl(PHPUNIT_TESTSUITE_EXTENSION_SELENIUM_TESTS_URL);
+    }
+}

--- a/selenium-1-tests/selenese/test_selenese_directory.html
+++ b/selenium-1-tests/selenese/test_selenese_directory.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="" />
+<title>todo:createTodo</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">Test SeleneseDirectory integration</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>html/test_open.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertTitle</td>
+	<td>Test open</td>
+	<td></td>
+</tr>
+
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
A failing test case for selenese integration which gives the following fatal error:

```
PHP Fatal error:  Call to undefined method PHPUnit_Extensions_SeleniumTestSuite::getSeleneseFiles() in /home/lsolesen/workspace/phpunit-selenium/PHPUnit/Extensions/SeleniumTestSuite.php on line 89
```

Test case has been placed in the root directory which is the only way (as far as I can tell) to make it run correctly using:

```
phpunit SeleneseTest.php
```

The reason I cannot put it somewhere else is because of the $seleneseDirectory which can only be relative to the testcase, so if I run it like:

```
phpunit Tests/SeleneseTest.php
```

it will not find any tests.

This pull request is for gh-134.
