### PR TITLE
Add support for 'link text' locator strategy

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -219,6 +219,15 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
     }
 
     /**
+     * @param string $value     e.g. 'Link text'
+     * @return PHPUnit_Extensions_Selenium2TestCase_Element
+     */
+    public function byLinkText($value)
+    {
+        return $this->by('link text', $value);
+    }
+
+    /**
      * @param string $strategy     supported by JsonWireProtocol element/ command
      * @param string $value
      * @return PHPUnit_Extensions_Selenium2TestCase_Element

--- a/Tests/Selenium2TestCaseTest.php
+++ b/Tests/Selenium2TestCaseTest.php
@@ -229,6 +229,14 @@ class Extensions_Selenium2TestCaseTest extends Tests_Selenium2TestCase_BaseTestC
         $this->assertEquals('Click Page 1', $this->title());
     }
 
+    public function testByLinkText()
+    {
+	$this->url('html/test_click_page1.html');
+	$link = $this->byLinkText('Click here for next page');
+	$link->click();
+	$this->assertEquals('Click Page Target', $this->title());
+    }
+
     public function testClicksOnJavaScriptHref()
     {
         $this->url('html/test_click_javascript_page.html');


### PR DESCRIPTION
Hi,

I added support for 'link text' selector and coresponding tests. 

Bartek
