### PR TITLE
Update PHPUnit/Extensions/SeleniumTestCase/Driver.php

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -274,6 +274,14 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
 
         $this->name = $name;
     }
+    
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
     /**
      * @param  string $browser


### PR DESCRIPTION
Adding getName() to driver.
In my usage, I have several firefox $browsers running different
profiles for different user agent strings, where the only way to differentiate them is the name.

```
    public static $browsers = array(
            array(
                    'name'    => 'firefox',
                    'browser' => '*firefox',
                    'host'    => 'localhost',
                    'port'    => 4444,
                    'timeout' => 30000,
            ),
            array(
                    'name'    => 'iphone',
                    'browser' => '*firefox',
                    'host'    => 'localhost',
                    'port'    => 4445,
                    'timeout' => 30000,
            ),
            array(
                    'name'    => 'android',
                    'browser' => '*firefox',
                    'host'    => 'localhost',
                    'port'    => 4446,
                    'timeout' => 30000,
            )
    );
```

```
        switch($this->drivers[0]->getName()){
            case "firefox":
                $this->assertLocation("/");
                break;
            case "iphone":
                $this->assertLocation("regex:itunes");
                break;
            case "android":
                $this->assertLocation("/");
                break;
            default:
                $this->fail("Invalid browser name");
        }
```
