### PR TITLE
Update ScreenshotListener to work on Windows

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/ScreenshotListener.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/ScreenshotListener.php
@@ -74,7 +74,7 @@ class PHPUnit_Extensions_Selenium2TestCase_ScreenshotListener implements PHPUnit
  
     private function storeAScreenshot(PHPUnit_Framework_Test $test)
     {
-        $file = $this->directory . '/' . get_class($test) . '__' . $test->getName() . '__ ' . date('Y-m-d\TH:i:s') . '.png';
+        $file = $this->directory . '/' . get_class($test) . '__' . $test->getName() . '__ ' . date('Y-m-d\TH-i-s') . '.png';
         file_put_contents($file,        $test->currentScreenshot());
     }
  


### PR DESCRIPTION
ScreenshotListener make filename with ":", but ":" is denied on Windows in filename
