### PR TITLE
Fix for situation when before launching the test browser window is closed

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -470,6 +470,20 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends PHPUnit_Framework_Te
     }
 
     /**
+     * @param int $timeout
+     */
+    public function waitForWindowClosed($timeout = null)
+    {
+        $this->waitUntil(function ($testCase) {
+            try {
+                $testCase->currentWindow();
+            } catch (RuntimeException $e) {
+                return true;
+            }
+        }, $timeout);
+    }
+
+    /**
      * Sends a special key
      * @param string $name
      * @throws PHPUnit_Extensions_Selenium2TestCase_Exception

--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -347,7 +347,6 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
     public function closeWindow()
     {
         $this->driver->curl('DELETE', $this->url->descend('window'));
-        sleep(1);
     }
 
     /**

--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -172,7 +172,10 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
         if ($this->stopped) {
             return;
         }
-        $this->driver->curl('DELETE', $this->url);
+        try {
+            $this->driver->curl('DELETE', $this->url);
+        } catch (RuntimeException $e) {
+        }
         $this->stopped = TRUE;
     }
 

--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -66,7 +66,7 @@
  * @method void|string url($url = NULL)
  * @method void window($name) Changes the focus to another window
  * @method string windowHandle() Retrieves the current window handle
- * @method string windowHandles() Retrieves a list of all available window handles
+ * @method array windowHandles() Retrieves a list of all available window handles
  * @method string keys() Send a sequence of key strokes to the active element.
  */
 class PHPUnit_Extensions_Selenium2TestCase_Session
@@ -322,6 +322,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
     public function closeWindow()
     {
         $this->driver->curl('DELETE', $this->url->descend('window'));
+        sleep(1);
     }
 
     /**

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
@@ -77,15 +77,13 @@ class PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared
         }
         if ($this->session === NULL) {
             $this->session = $this->original->session($parameters);
-            $this->mainWindow = $this->session->windowHandle();
         } else {
             try {
-                sleep(1); //Sometimes there is not enough time the window to be closed
-                $this->session->window($this->mainWindow);
+                list($window) = $this->session->windowHandles();
+                $this->session->window($window);
             } catch (RuntimeException $e) {
                 $this->session->stop();
                 $this->session = $this->original->session($parameters);
-                $this->mainWindow = $this->session->windowHandle();
             }
         }
         return $this->session;

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
@@ -56,9 +56,17 @@
 class PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared
     implements PHPUnit_Extensions_Selenium2TestCase_SessionStrategy
 {
+    /**
+     * @var PHPUnit_Extensions_Selenium2TestCase_SessionStrategy
+     */
     private $original;
+    /**
+     * @var PHPUnit_Extensions_Selenium2TestCase_Session
+     */
     private $session;
-    private $mainWindow;
+    /**
+     * @var bool
+     */
     private $lastTestWasNotSuccessful = FALSE;
 
     public function __construct(PHPUnit_Extensions_Selenium2TestCase_SessionStrategy $originalStrategy)
@@ -79,11 +87,18 @@ class PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared
             $this->session = $this->original->session($parameters);
         } else {
             try {
-                list($window) = $this->session->windowHandles();
-                $this->session->window($window);
-            } catch (RuntimeException $e) {
+                $this->session->window($this->session->windowHandle());
+            } catch (Exception $e) {
+                $errorMessage = $e->getMessage();
+                if (strpos($errorMessage, 'Session not found') === FALSE
+                    && strpos($errorMessage, 'It may have died') === FALSE
+                    && strpos($errorMessage, 'Window not found') === FALSE
+                ) {
+                    throw $e;
+                }
                 $this->session->stop();
-                $this->session = $this->original->session($parameters);
+                $this->session = NULL;
+                return $this->session($parameters);
             }
         }
         return $this->session;

--- a/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
@@ -69,7 +69,7 @@ class PHPUnit_Extensions_Selenium2TestCase_WaitUntil
      *
      * @var int
      */
-    private $_defaultTimeout = 0;
+    private $_defaultTimeout = 40000;
 
     /**
      * The sleep interval between iterations, ms

--- a/Tests/Selenium2TestCase/SharedSessionTest.php
+++ b/Tests/Selenium2TestCase/SharedSessionTest.php
@@ -91,4 +91,27 @@ class Extensions_SharedSessionTest extends PHPUnit_Extensions_Selenium2TestCase
     {
         $this->assertSame(PHPUNIT_TESTSUITE_EXTENSION_SELENIUM_TESTS_URL, $this->url());
     }
+
+    public function testCloseBrowserAfterOpenOne()
+    {
+        $this->execute(array('script' => "window.open()", 'args' => array()));
+        $this->closeWindow();
+    }
+
+    public function testVerifyBrowserOpenedAfterSuccessTestWithTwoWindows()
+    {
+        $this->assertSame(PHPUNIT_TESTSUITE_EXTENSION_SELENIUM_TESTS_URL, $this->url());
+    }
+
+    public function testCloseBrowserAfterOpenOneAndFail()
+    {
+        $this->execute(array('script' => "window.open()", 'args' => array()));
+        $this->closeWindow();
+        $this->fail('Fail for verify next test');
+    }
+
+    public function testVerifyBrowserOpenedAfterFailedTestWithTwoWindows()
+    {
+        $this->assertSame(PHPUNIT_TESTSUITE_EXTENSION_SELENIUM_TESTS_URL, $this->url());
+    }
 }

--- a/Tests/Selenium2TestCase/SharedSessionTest.php
+++ b/Tests/Selenium2TestCase/SharedSessionTest.php
@@ -74,6 +74,7 @@ class Extensions_SharedSessionTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testCloseBrowser()
     {
         $this->closeWindow();
+        $this->waitForWindowClosed();
     }
 
     public function testVerifyBrowserOpenedAfterSuccessTest()
@@ -84,6 +85,7 @@ class Extensions_SharedSessionTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testCloseBrowserAndFail()
     {
         $this->closeWindow();
+        $this->waitForWindowClosed();
         $this->fail('Fail for verify next test');
     }
 
@@ -96,6 +98,7 @@ class Extensions_SharedSessionTest extends PHPUnit_Extensions_Selenium2TestCase
     {
         $this->execute(array('script' => "window.open()", 'args' => array()));
         $this->closeWindow();
+        $this->waitForWindowClosed();
     }
 
     public function testVerifyBrowserOpenedAfterSuccessTestWithTwoWindows()
@@ -107,6 +110,7 @@ class Extensions_SharedSessionTest extends PHPUnit_Extensions_Selenium2TestCase
     {
         $this->execute(array('script' => "window.open()", 'args' => array()));
         $this->closeWindow();
+        $this->waitForWindowClosed();
         $this->fail('Fail for verify next test');
     }
 


### PR DESCRIPTION
The situation when before launching the test browser window is closed and 'sessionStrategy' parameter is equal to 'shared' is fixed