### PR TITLE
Update PHPUnit/Extensions/Selenium2TestCase/Session.php

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -278,7 +278,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
      */
     public function select(PHPUnit_Extensions_Selenium2TestCase_Element $element)
     {
-        $tag = $element->name();
+        $tag = strtolower($element->name());
         if ($tag !== 'select') {
             throw new InvalidArgumentException("The element is not a `select` tag but a `$tag`.");
         }


### PR DESCRIPTION
$element->name() returns 'SELECT' for select element in Safari browser, trowing exception "The element is not a `select` tag but a `SELECT`".
