### PR TITLE
Selenium2TestCaseTest.php: Fix minor copy/paste error in class DocBlock

### DIFF
--- a/Tests/Selenium2TestCaseTest.php
+++ b/Tests/Selenium2TestCaseTest.php
@@ -42,7 +42,7 @@
  */
 
 /**
- * Tests for PHPUnit_Extensions_SeleniumTestCase.
+ * Tests for PHPUnit_Extensions_Selenium2TestCase.
  *
  * @package    PHPUnit_Selenium
  * @author     Giorgio Sironi <info@giorgiosironi.com>


### PR DESCRIPTION
Minor DocBlock correction -- the "2" is missing in the doc for the test class for PHPUnit_Extensions_Selenium2TestCase.

Love PHPUnit!
