### PR TITLE
Need to trim {} symbols from window handle

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -329,7 +329,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
      */
     public function currentWindow()
     {
-        $url = $this->url->descend('window')->descend($this->windowHandle());
+        $url = $this->url->descend('window')->descend(trim($this->windowHandle(), '{}'));
         return new PHPUnit_Extensions_Selenium2TestCase_Window($this->driver, $url);
     }
 


### PR DESCRIPTION
When trying to use maximize we are getting URL in currentWindow() like /session/bb6349f5-933f-48b2-a96c-d262f9b5acb5/window/{9a917499-db6e-4958-9307-0052c5e67d76}/maximize . But it would be great to get URL like /session/bb6349f5-933f-48b2-a96c-d262f9b5acb5/window/9a917499-db6e-4958-9307-0052c5e67d76/maximize (without { and }). 
The problem is selenium-server in hub mode cannot post request to the node. Seems java.net.URI library is not parsing such URL as correct one and cannot create request.
