### PR TITLE
waitUntil is resetting implicitWait

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
@@ -120,6 +120,10 @@ class PHPUnit_Extensions_Selenium2TestCase_WaitUntil
                 $result = $callback($this->_testCase);
 
                 if (!is_null($result)) {
+                    if ($implicitWait) {
+                        $this->_testCase->timeouts()->implicitWait($implicitWait);
+                    }
+
                     return $result;
                 }
             } catch(Exception $e) {

--- a/Tests/Selenium2TestCase/WaitUntilTest.php
+++ b/Tests/Selenium2TestCase/WaitUntilTest.php
@@ -90,7 +90,7 @@ class Tests_Selenium2TestCase_WaitUntilTest extends Tests_Selenium2TestCase_Base
         $this->waitUntil('not a callback');
     }
 
-    public function testImplicitWaitIsRestored()
+    public function testImplicitWaitIsRestoredAfterFailure()
     {
         $this->url('html/test_wait.html');
         $this->timeouts()->implicitWait(7000);
@@ -104,6 +104,21 @@ class Tests_Selenium2TestCase_WaitUntilTest extends Tests_Selenium2TestCase_Base
         } catch (PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {}
 
         // in this case - element should be found, because of the implicitWait
+        $element = $this->byId('testBox');
+        $this->assertEquals('testBox', $element->attribute('id'));
+    }
+
+    public function testImplicitWaitIsRestoredAfterSuccess()
+    {
+        $this->url('html/test_wait.html');
+        $this->timeouts()->implicitWait(8000);
+
+        $this->waitUntil(function($testCase) {
+            $testCase->byId('parent');
+            return true;
+        });
+
+        // in this case - element should be found, because we set a 8000ms implicitWait before the waitUntil.
         $element = $this->byId('testBox');
         $this->assertEquals('testBox', $element->attribute('id'));
     }


### PR DESCRIPTION
Right now, waitUntil() leaves implicitWait timeout in a zero'd out state on success. It was only restoring the prior state on failure. Includes test.
