### PR TITLE
Update SeleniumTestCase.php

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -1196,4 +1196,12 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
             return '';
         }
     }
+    
+    /**
+     * Pause support for runSelenese() HTML cases
+     * @param $milliseconds
+     */
+    protected function pause($milliseconds){
+		sleep(round($milliseconds/1000));
+	}
 }


### PR DESCRIPTION
Pause support for runSelenese() HTML cases
Otherwise they fail with PHPUnit_Framework_Error : 
Invalid response while accessing the Selenium Server at 'http://localhost:4444/selenium-server/driver/': ERROR: Unknown command: 'pause'
