### PR TITLE
Wrong status of failed test

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Driver.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Driver.php
@@ -140,7 +140,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Driver
             } else {
                 $message = "Internal server error while executing $http_method request at $url. Response: " . var_export($content, TRUE);
             }
-            throw new PHPUnit_Extensions_Selenium2TestCase_WebDriverException($message, isset($content['status']) ? $content['status'] : 0);
+            throw new PHPUnit_Extensions_Selenium2TestCase_WebDriverException($message, isset($content['status']) ? $content['status'] : 13);
         }
         return new PHPUnit_Extensions_Selenium2TestCase_Response($content, $info);
     }


### PR DESCRIPTION
if we don't have 'status' key in array we set '0' value, and '0' means 'The command executed successfully.'
http://code.google.com/p/selenium/wiki/JsonWireProtocol#Response_Status_Codes
