### PR TITLE
Fix lower element name on select method.

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session.php
@@ -308,7 +308,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Session
      */
     public function select(PHPUnit_Extensions_Selenium2TestCase_Element $element)
     {
-        $tag = $element->name();
+        $tag = strtolower($element->name());
         if ($tag !== 'select') {
             throw new InvalidArgumentException("The element is not a `select` tag but a `$tag`.");
         }


### PR DESCRIPTION
In my environment
`InvalidArgumentException: The element is not a `select` tag but a `SELECT`.`
Fix this exception.

But I can not understand why name is not "select" but "SELECT". ( using "select" in a html)
Please refuse if this commit is a bad fix.
