### PR TITLE
Fix docblocks for autocompletion on eclipse pdt

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -55,34 +55,34 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 1.2.0
  * @method void acceptAlert() Press OK on an alert, or confirms a dialog
- * @method mixed alertText($value = NULL) Gets the alert dialog text, or sets the text for a prompt dialog
+ * @method mixed alertText() alertText($value = NULL) Gets the alert dialog text, or sets the text for a prompt dialog
  * @method void back()
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byClassName($vaue)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byCssSelector($value)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byId($value)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byLinkText($value)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byName($value)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byTag($value)
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element byXPath($value)
- * @method void click(int $button = 0) Click any mouse button (at the coordinates set by the last moveto command).
- * @method void clickOnElement($id)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byClassName() byClassName($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byCssSelector() byCssSelector($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byId() byId($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byLinkText() byLinkText($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byName() byName($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byTag() byTag($value)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element byXPath() byXPath($value)
+ * @method void click() click(int $button = 0) Click any mouse button (at the coordinates set by the last moveto command).
+ * @method void clickOnElement() clickOnElement($id)
  * @method string currentScreenshot() BLOB of the image file
  * @method void dismissAlert() Press Cancel on an alert, or does not confirm a dialog
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element element(\PHPUnit_Extensions_Selenium2TestCase_ElementCriteria $criteria) Retrieves an element
- * @method array elements(\PHPUnit_Extensions_Selenium2TestCase_ElementCriteria $criteria) Retrieves an array of Element instances
- * @method string execute($javaScriptCode) Injects arbitrary JavaScript in the page and returns the last
- * @method string executeAsync($javaScriptCode) Injects arbitrary JavaScript and wait for the callback (last element of arguments) to be called
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element element() element(\PHPUnit_Extensions_Selenium2TestCase_ElementCriteria $criteria) Retrieves an element
+ * @method array elements() elements(\PHPUnit_Extensions_Selenium2TestCase_ElementCriteria $criteria) Retrieves an array of Element instances
+ * @method string execute() execute($javaScriptCode) Injects arbitrary JavaScript in the page and returns the last
+ * @method string executeAsync() executeAsync($javaScriptCode) Injects arbitrary JavaScript and wait for the callback (last element of arguments) to be called
  * @method void forward()
- * @method void frame(mixed $element) Changes the focus to a frame in the page (by frameCount of type int, htmlId of type string, htmlName of type string or element of type \PHPUnit_Extensions_Selenium2TestCase_Element)
- * @method void moveto(\PHPUnit_Extensions_Selenium2TestCase_Element $element) Move the mouse by an offset of the specificed element.
+ * @method void frame() frame(mixed $element) Changes the focus to a frame in the page (by frameCount of type int, htmlId of type string, htmlName of type string or element of type \PHPUnit_Extensions_Selenium2TestCase_Element)
+ * @method void moveto() moveto(\PHPUnit_Extensions_Selenium2TestCase_Element $element) Move the mouse by an offset of the specificed element.
  * @method void refresh()
- * @method \PHPUnit_Extensions_Selenium2TestCase_Element_Select select($element)
+ * @method \PHPUnit_Extensions_Selenium2TestCase_Element_Select select() select($element)
  * @method string source() Returns the HTML source of the page
  * @method \PHPUnit_Extensions_Selenium2TestCase_Session_Timeouts timeouts()
  * @method string title()
- * @method void|string url($url = NULL)
- * @method PHPUnit_Extensions_Selenium2TestCase_ElementCriteria using($strategy) Factory Method for Criteria objects
- * @method void window($name) Changes the focus to another window
+ * @method void|string url() url($url = NULL)
+ * @method PHPUnit_Extensions_Selenium2TestCase_ElementCriteria using() using($strategy) Factory Method for Criteria objects
+ * @method void window() window($name) Changes the focus to another window
  * @method string windowHandle() Retrieves the current window handle
  * @method string windowHandles() Retrieves a list of all available window handles
  * @method string keys() Send a sequence of key strokes to the active element.


### PR DESCRIPTION
This patch fixes some errors for Eclipse PDT. If using auto completion all methods with parameters are not completed properly. Now it works. I tested it with Eclipse and Netbeans.
