### PR TITLE
Accessor byPartialLinkText

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Element/Accessor.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Element/Accessor.php
@@ -91,6 +91,15 @@ abstract class PHPUnit_Extensions_Selenium2TestCase_Element_Accessor
     }
 
     /**
+     * @param string $value     e.g. 'Link te'
+     * @return PHPUnit_Extensions_Selenium2TestCase_Element
+     */
+    public function byPartialLinkText($value)
+    {
+        return $this->by('partial link text', $value);
+    }
+
+    /**
      * @param string $value     e.g. 'email_address'
      * @return PHPUnit_Extensions_Selenium2TestCase_Element
      */

--- a/Tests/Selenium2TestCaseTest.php
+++ b/Tests/Selenium2TestCaseTest.php
@@ -299,6 +299,14 @@ class Extensions_Selenium2TestCaseTest extends Tests_Selenium2TestCase_BaseTestC
         $this->assertEquals('Click Page Target', $this->title());
     }
 
+    public function testByPartialLinkText()
+    {
+        $this->url('html/test_click_page1.html');
+        $link = $this->byLinkText('next page');
+        $link->click();
+        $this->assertEquals('Click Page Target', $this->title());
+    }
+
     public function testClicksOnJavaScriptHref()
     {
         $this->url('html/test_click_javascript_page.html');


### PR DESCRIPTION
According to [Selenium Wire Protocol](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element), it can find element not only by (full) _link text_, but also by _partial link text_. This is not exposed in php api.
