### PR TITLE
Missing session

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Response.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Response.php
@@ -83,6 +83,6 @@ class PHPUnit_Extensions_Selenium2TestCase_Response
      */
     public function getURL()
     {
-        return new PHPUnit_Extensions_Selenium2TestCase_URL($this->info['url']);
+        return new PHPUnit_Extensions_Selenium2TestCase_URL($this->info['url'] . '/' . $this->jsonResponse['sessionId']);
     }
 }


### PR DESCRIPTION
After Selenium 2.34+ versions, if you run the tests, the sessionId is missing from the URL.
(BadMethodCallException: The command http://localhost:4444/wd/hub/session/url is not recognized by the server. shown)
It should be http://localhost:4444/wd/hub/session/{sessionId}/url. The sessionId is not being appended to the URL
