### PR TITLE
Use call_user_func in waitUntil to run a callback

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/WaitUntil.php
@@ -117,7 +117,7 @@ class PHPUnit_Extensions_Selenium2TestCase_WaitUntil
 
         while (TRUE) {
             try {
-                $result = $callback($this->_testCase);
+                $result = call_user_func($callback, $this->_testCase);
 
                 if (!is_null($result)) {
                     if ($implicitWait) {


### PR DESCRIPTION
This allows methods as callback. Since the argument is checked by is_callable which allows array($object, $method) style callbacks.
