### PR TITLE
Escape testId when constructing URL

### DIFF
--- a/PHPUnit/Extensions/SeleniumCommon/RemoteCoverage.php
+++ b/PHPUnit/Extensions/SeleniumCommon/RemoteCoverage.php
@@ -13,7 +13,7 @@ class PHPUnit_Extensions_SeleniumCommon_RemoteCoverage
             $url = sprintf(
               '%s?PHPUNIT_SELENIUM_TEST_ID=%s',
               $this->coverageScriptUrl,
-              $this->testId
+              urlencode($this->testId)
             );
 
             $buffer = @file_get_contents($url);


### PR DESCRIPTION
When trying to set up Selenium tests I ran into issue that getting coverage fails on tests using `@dataProvider`. The problem here is probably in fact that the test case name in this case is something like `footest with data set #42`, what should be escaped when used in the URL to request coverage data.

I've tried to fix this, but not sure if there is other code which would be affected by this as well.
