### PR TITLE
Added backward-compatible implementation for the `$element->value()` method

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Element.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Element.php
@@ -161,7 +161,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Element
 
     /**
      * Get or set value of form elements. If the element already has a value, the set one will be appended to it.
-     * Created **ONLY** for keeping backward compatibility, since in selenium v2.40.0 it was removed
+     * Created **ONLY** for keeping backward compatibility, since in selenium v2.42.0 it was removed
      * The currently recommended solution is to use `$element->attribute('value')`
      * @see https://code.google.com/p/selenium/source/detail?r=953007b48e83f90450f3e41b11ec31e2928f1605
      * @see https://code.google.com/p/selenium/source/browse/java/CHANGELOG


### PR DESCRIPTION
Added backward-compatible implementation for the `$element->value()` method that was introduced in selenium v2.42.0

See:
- https://code.google.com/p/selenium/source/browse/java/CHANGELOG (search for `getValue` keyword)
- https://code.google.com/p/selenium/source/detail?r=953007b48e83f90450f3e41b11ec31e2928f1605

Steps to reproduce the issue:

```
vendor/bin/phpunit --filter testTypingViaTheKeyboard Tests/Selenium2TestCaseTest.php
```

This test would emit the `GET /session/:sessionId/element/:id/value` request that isn't the part of JsonWire protocol. So the selenium v2.42.0 (and higher) return `HTTP 500` response for the request.

For further use it's supposed one will use `$element->attribute('value')`
