### PR TITLE
Added Vagrantfile which sets up the essential environment for `phpunit-selenium` hacking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ firefox/
 /.project
 /.buildpath
 /.settings
+/.vagrant/

--- a/.vagrant/phpunit-environment.conf
+++ b/.vagrant/phpunit-environment.conf
@@ -1,0 +1,11 @@
+[program:xvfb]
+command=Xvfb :10 -ac
+
+[program:selenium]
+command=java -jar /usr/share/selenium/selenium-server-standalone.jar
+environment=DISPLAY=":10"
+
+[program:python-webserver]
+command=python -m SimpleHTTPServer 8080
+directory=/vagrant/selenium-1-tests
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A feature branch containing all the commits you want to propose works best.
 Running the test suite
 ---
 
+#### Manually
+
 To run the test suite for this package, you should serve selenium-1-tests via HTTP:
 ```
 selenium-1-tests/ $ python -m SimpleHTTPServer 8080
@@ -31,3 +33,15 @@ The tests can then be run with:
 $ vendor/bin/phpunit Tests
 ```
 You can copy phpunit.xml.dist to phpunit.xml and setup a custom configuration for browsers, but the test suite is based on Firefox on an Ubuntu machine.
+
+#### Via Vagrant
+
+Just run `vagrant up` and everything will be set up for you. The first start will take some time which depends on the speed of your connection (and less - speed of your computer). It will take about 160Mb to set up the VM environment and about 300Mb to download the `hashicorp/precise32` vagrant box (in case if you don't have it downloaded yet).
+
+After the command finishes its execution just run the following:
+
+    vagrant ssh # logging in into the just created virtual machine
+    cd /vagrant
+    vendor/bin/phpunit Tests/Selenium2TestCaseTest.php
+    
+and you must see the `phpunit` testing `phpunit-selenium` project.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+VAGRANTFILE_API_VERSION = "2"
+
+$setupEnvironment = <<-SCRIPT
+
+sed -i "/mirror:\\/\\//d" /etc/apt/sources.list
+sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise main restricted universe multiverse" /etc/apt/sources.list
+sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates main restricted universe multiverse" /etc/apt/sources.list
+sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-backports main restricted universe multiverse" /etc/apt/sources.list
+sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-security main restricted universe multiverse" /etc/apt/sources.list
+
+apt-get update
+
+# firefox and xvfb
+apt-get install firefox xvfb -y --no-install-recommends
+
+# java
+apt-get install openjdk-7-jre-headless -y --no-install-recommends
+
+# selenium
+mkdir -p /usr/share/selenium
+if [ ! -f "/usr/share/selenium/selenium-server-standalone.jar" ]; then echo "Downloading selenium (~35Mb) ..."; wget -nv -O /usr/share/selenium/selenium-server-standalone.jar http://selenium-release.storage.googleapis.com/2.41/selenium-server-standalone-2.41.0.jar; fi
+
+# php
+apt-get install php5-cli php5-curl php5-xdebug -y --no-install-recommends
+if [ ! -f "/usr/local/bin/composer" ]; then php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer; fi
+
+# supervisor
+apt-get install supervisor -y --no-install-recommends
+cp /vagrant/.vagrant/phpunit-environment.conf /etc/supervisor/conf.d/
+service supervisor stop
+sleep 5
+service supervisor start
+
+# project
+cd /vagrant
+if [ ! -d "vendor" ]; then composer install --dev; fi
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise32"
+
+  config.vm.provision "shell", inline: $setupEnvironment
+end


### PR DESCRIPTION
It is painful to set up the development environment for `phpunit-selenium` so I've added a `Vagrantfile` that sets up the complete environment to develop and test `phpunit-selenium`

It includes:
- headless `firefox` (via `xvfb`)
- `selenium-server-standalone-2.41.0` (there are some issues with `v2.42`, see https://github.com/sebastianbergmann/phpunit-selenium/pull/311)
- `php5` and `composer`
- `supervisord` to run `selenium` and `xvfb`

Known issues:
- Currently one test for `Selenium2TestCaseTest.php` fails, I will check why it does soon
- Some other fails for `Selenium2TestCase` directory (but to be honest I have never seen them working)
#### How to use:

As easy as a single `vagrant up` command and everything is done (after few minutes on first start)
