### PR TITLE
Expanding Screenshot Parameters Boundings

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase/Driver.php
+++ b/PHPUnit/Extensions/SeleniumTestCase/Driver.php
@@ -261,6 +261,14 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
     {
         $this->testId = $testId;
     }
+	
+	/**
+     * @return integer $testId
+     */
+    public function getTestId()
+    {
+        return $this->testId;
+    }
 
     /**
      * @param  string $name
@@ -360,7 +368,7 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
     {
         return $this->port;
     }
-
+	
     /**
      * @param  integer $timeout for Selenium RC in seconds
      * @throws InvalidArgumentException
@@ -431,7 +439,47 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
 
         $this->useWaitForPageToLoad = $flag;
     }
+	/**
+     * Sets whether captureScreenshotOnFailure (TRUE) or (FALSE)
+     * if true, the takeScreenshot() is triggered in onNotSuccessfulTest().
+     *
+     * @param  boolean $flag
+     * @throws InvalidArgumentException
+     */
+	public function setCaptureScreenshotOnFailure($flag)
+    {
+        if (!is_bool($flag)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'boolean');
+        }
 
+        $this->captureScreenshotOnFailure = $flag;
+    }
+	
+	/**
+     * @param  string $screenshotUrl
+     * @throws InvalidArgumentException
+     */
+    public function setScreenshotUrl($screenshotUrl)
+    {
+        if (!is_string($screenshotUrl)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->screenshotUrl = $screenshotUrl;
+    }
+	/**
+     * @param  string $screenshotPath
+     * @throws InvalidArgumentException
+     */
+    public function setScreenshotPath($screenshotPath)
+    {
+        if (!is_string($screenshotPath)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->screenshotPath = $screenshotPath;
+    }
+	
     /**
      * Adds allowed user commands into {@link self::$userCommands}. See
      * {@link self::__call()} (switch/case -> default) for usage.
@@ -441,6 +489,8 @@ class PHPUnit_Extensions_SeleniumTestCase_Driver
      * @return $this
      * @see    self::__call()
      */
+	 
+	
     public function addUserCommand($command)
     {
         if (!is_string($command)) {


### PR DESCRIPTION
Me and my teammates were making tests and set our own suite procedures using Phpunit/Selenium, and we figured out that the screenshot functionality related to the captureScreenshotOnFailure is bound to a specific fileName. I've added some public setters captureScreenshotOnFailure(), setScreenshotUrl(), setScreenshotPath() because such parameters are protected, and getTestId() in case any tester doesn't want to change the default unique test id, just to know its id/screenshot filename, these simple functions were not implemented, here they are.
