### PR TITLE
initialization of WebDriver's "file" command added

### DIFF
--- a/PHPUnit/Extensions/SeleniumCommon/Autoload.php
+++ b/PHPUnit/Extensions/SeleniumCommon/Autoload.php
@@ -82,6 +82,7 @@ spl_autoload_register(
             'phpunit_extensions_selenium2testcase_sessioncommand_alerttext' => '/Extensions/Selenium2TestCase/SessionCommand/AlertText.php',
             'phpunit_extensions_selenium2testcase_sessioncommand_click' => '/Extensions/Selenium2TestCase/SessionCommand/Click.php',
             'phpunit_extensions_selenium2testcase_sessioncommand_dismissalert' => '/Extensions/Selenium2TestCase/SessionCommand/DismissAlert.php',
+            'phpunit_extensions_selenium2testcase_sessioncommand_file' => '/Extensions/Selenium2TestCase/SessionCommand/File.php',
             'phpunit_extensions_selenium2testcase_sessioncommand_frame' => '/Extensions/Selenium2TestCase/SessionCommand/Frame.php',
             'phpunit_extensions_selenium2testcase_sessioncommand_genericaccessor' => '/Extensions/Selenium2TestCase/SessionCommand/GenericAccessor.php',
             'phpunit_extensions_selenium2testcase_sessioncommand_genericattribute' => '/Extensions/Selenium2TestCase/SessionCommand/GenericAttribute.php',


### PR DESCRIPTION
There wasn't initialized "file" command!

Command "file" is usefull for transfering local file to remote server when you run Selenium server on remote machine.
