### PR TITLE
Updated return type in Cookie.php

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session/Cookie.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session/Cookie.php
@@ -68,7 +68,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Session_Cookie
     /**
      * @param string $name
      * @param string $value
-     * @return void
+     * @return PHPUnit_Extensions_Selenium2TestCase_Session_Cookie_Builder
      */
     public function add($name, $value)
     {


### PR DESCRIPTION
Changed return type in comment block above add function to return the
correct object,
PHPUnit_Extensions_Selenium2TestCase_Session_Cookie_Builder, instead of
void.
