### PR TITLE
Replace the value() methods calls by attribute('value')

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Element/Select.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Element/Select.php
@@ -85,7 +85,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Element_Select
         if ($selectedOption === NULL) {
             return '';
         }
-        return $selectedOption->value();
+        return $selectedOption->attribute('value');
     }
 
     /**
@@ -119,7 +119,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Element_Select
     {
         $values = array();
         foreach ($this->selectedOptions() as $option) {
-            $values[] = $option->value();
+            $values[] = $option->attribute('value');
         }
         return $values;
     }
@@ -175,7 +175,7 @@ class PHPUnit_Extensions_Selenium2TestCase_Element_Select
     {
         $options = array();
         foreach ($this->options() as $option) {
-            $options[] = $option->value();
+            $options[] = $option->attribute('value');
         }
         return $options;
     }


### PR DESCRIPTION
This method is not supported by recent browsers drivers anymore and cause errors if called.
See: https://code.google.com/p/selenium/source/detail?r=953007b48e83f90450f3e41b11ec31e2928f1605
We have to replace the "->value()" calls by "->attribute('value')"