### PR TITLE
Added logic to remove trailing slash from URL

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/URL.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/URL.php
@@ -65,6 +65,9 @@ final class PHPUnit_Extensions_Selenium2TestCase_URL
      */
     public function __construct($value)
     {
+	if (substr($value, -1) == '/' ) {
+            $value = substr($value, 0, strlen($value)-1);
+        }
         $this->value = $value;
     }
 


### PR DESCRIPTION
A trailing slash causes an invalid sessionId to be returned.