### PR TITLE
PHP Warning:  Declaration of PHPUnit_Extensions_Selenium2TestCase::on…

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -321,7 +321,7 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends PHPUnit_Framework_Te
         return PHPUnit_Extensions_SeleniumTestSuite::fromTestCaseClass($className);
     }
 
-    public function onNotSuccessfulTest(Exception $e)
+    public function onNotSuccessfulTest($e)
     {
         $this->getStrategy()->notSuccessfulTest();
         parent::onNotSuccessfulTest($e);


### PR DESCRIPTION
…NotSuccessfulTest(Exception $e) be compatible with PHPUnit_Framework_TestCase::onNotSuccessfulTest($e)

The overriding method does not match the signature of the parent anymore since PHPUnit 5.0.0.

https://github.com/sebastianbergmann/phpunit/commit/43aa49206b155931db36463c6b908a29d32361aa
