### PR TITLE
Make compatible with phpunit 5.x

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestCase.php
+++ b/PHPUnit/Extensions/SeleniumTestCase.php
@@ -483,7 +483,7 @@ abstract class PHPUnit_Extensions_SeleniumTestCase extends PHPUnit_Framework_Tes
         // Create tests from test methods for single browser.
         else {
             foreach ($class->getMethods() as $method) {
-                if (PHPUnit_Framework_TestSuite::isPublicTestMethod($method)) {
+                if (PHPUnit_Framework_TestSuite::isTestMethod($method)) {
                     $name   = $method->getName();
                     $data   = PHPUnit_Util_Test::getProvidedData($className, $name);
                     $groups = PHPUnit_Util_Test::getGroups($className, $name);


### PR DESCRIPTION
Changed PHPUnit_Framework_TestSuite::isPublicTestMethod to 
PHPUnit_Framework_TestSuite::isTestMethod
(because former was removed in phpunit 4.0).
