### PR TITLE
Only collect code coverage when a coverage url has been configured

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -309,7 +309,7 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends PHPUnit_Framework_Te
             $result = $this->createResult();
         }
 
-        $this->collectCodeCoverageInformation = $result->getCollectCodeCoverageInformation();
+        $this->collectCodeCoverageInformation = $result->getCollectCodeCoverageInformation() && $this->coverageScriptUrl;
 
         parent::run($result);
 


### PR DESCRIPTION
Hey!

I'm facing #395 and this PR tries to fix this specific issue. Basically, this PR disables code coverage if the coverage url has not been configured (meaning the developer doesn't care about code coverage for its selenium test cases).

Using my fork on one of my projects allows me to pass from this [build](https://travis-ci.org/egeloen/ivory-google-map/builds/191841718) to this [build](https://travis-ci.org/egeloen/ivory-google-map/builds/191920251) :)

What do you think?