### PR TITLE
Adding keepSeeionOnFail function.

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -166,6 +166,11 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends PHPUnit_Framework_Te
     /**
      * @param boolean
      */
+    private static $keepSeesionOnFail = FALSE;
+
+    /**
+     * @param boolean
+     */
     public static function shareSession($shareSession)
     {
         if (!is_bool($shareSession)) {
@@ -174,8 +179,20 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends PHPUnit_Framework_Te
         if (!$shareSession) {
             self::$sessionStrategy = self::defaultSessionStrategy();
         } else {
-            self::$sessionStrategy = new PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared(self::defaultSessionStrategy());
+            self::$sessionStrategy = new PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared(
+              self::defaultSessionStrategy(), self::$keepSeesionOnFail
+              );
         }
+    }
+
+    public static function keepSeesionOnFail($keepSession)
+    {
+      if (!is_bool($keepSession)) {
+            throw new InvalidArgumentException("The keep session on fail support can only be switched on or off.");
+        }
+      if ($keepSession){
+            self::$keepSeesionOnFail = TRUE;
+      }
     }
 
     private static function sessionStrategy()

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Shared.php
@@ -60,15 +60,18 @@ class PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Shared
     private $session;
     private $mainWindow;
     private $lastTestWasNotSuccessful = FALSE;
+    private $keepSeesionOnFail;
 
-    public function __construct(PHPUnit_Extensions_Selenium2TestCase_SessionStrategy $originalStrategy)
+    public function __construct(PHPUnit_Extensions_Selenium2TestCase_SessionStrategy $originalStrategy, $keepSeesionOnFail)
     {
         $this->original = $originalStrategy;
+        $this->keepSeesionOnFail = $keepSeesionOnFail;
+
     }
 
     public function session(array $parameters)
     {
-        if ($this->lastTestWasNotSuccessful) {
+        if ($this->lastTestWasNotSuccessful && !$this->keepSeesionOnFail) {
             if ($this->session !== NULL) {
                 $this->session->stop();
                 $this->session = NULL;


### PR DESCRIPTION
So you can keep using the same browser session when an assert fails or there's an error.