### PR TITLE
Added secure server flag for https selenium servers

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase.php
+++ b/PHPUnit/Extensions/Selenium2TestCase.php
@@ -256,7 +256,8 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends TestCase
             'browser' => NULL,
             'browserName' => NULL,
             'desiredCapabilities' => array(),
-            'seleniumServerRequestsTimeout' => 60
+            'seleniumServerRequestsTimeout' => 60,
+            'secure' => FALSE
         );
 
         $this->keysHolder = new PHPUnit_Extensions_Selenium2TestCase_KeysHolder();
@@ -377,7 +378,7 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends TestCase
         } catch (Exception $e) {
             $thrownException = $e;
         }
-        
+
         if ($this->collectCodeCoverageInformation) {
             $this->session->cookie()->remove('PHPUNIT_SELENIUM_TEST_ID');
         }
@@ -454,6 +455,24 @@ abstract class PHPUnit_Extensions_Selenium2TestCase extends TestCase
     public function getPort()
     {
         return $this->parameters['port'];
+    }
+
+    /**
+     * @param boolean $secure
+     * @throws InvalidArgumentException
+     */
+    public function setSecure($secure)
+    {
+        if(!is_bool($secure)) {
+            throw InvalidArgumentHelper::factory(1, 'boolean');
+        }
+
+        $this->parameters['secure'] = $secure;
+    }
+
+    public function getSecure()
+    {
+        return $this->parameters['secure'];
     }
 
     /**

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy.php
@@ -58,6 +58,7 @@ interface PHPUnit_Extensions_Selenium2TestCase_SessionStrategy
     /**
      * @param array $parameters 'host' => Selenium Server machine
                                 'port' => Selenium Server port
+                                'secure' => Selenium Server secure flag
                                 'browser' => a browser name 
      *                          'browserUrl' => base URL to use during the test
      */

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy.php
@@ -59,7 +59,7 @@ interface PHPUnit_Extensions_Selenium2TestCase_SessionStrategy
      * @param array $parameters 'host' => Selenium Server machine
                                 'port' => Selenium Server port
                                 'secure' => Selenium Server secure flag
-                                'browser' => a browser name 
+                                'browser' => a browser name
      *                          'browserUrl' => base URL to use during the test
      */
     public function session(array $parameters);

--- a/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Isolated.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/SessionStrategy/Isolated.php
@@ -58,7 +58,7 @@ class PHPUnit_Extensions_Selenium2TestCase_SessionStrategy_Isolated
 {
     public function session(array $parameters)
     {
-        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port']);
+        $seleniumServerUrl = PHPUnit_Extensions_Selenium2TestCase_URL::fromHostAndPort($parameters['host'], $parameters['port'], $parameters['secure']);
         $driver = new PHPUnit_Extensions_Selenium2TestCase_Driver($seleniumServerUrl, $parameters['seleniumServerRequestsTimeout']);
         $capabilities = array_merge($parameters['desiredCapabilities'],
                                     array(

--- a/PHPUnit/Extensions/Selenium2TestCase/URL.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/URL.php
@@ -80,7 +80,7 @@ final class PHPUnit_Extensions_Selenium2TestCase_URL
         if ($secure) {
             $prefix = "https://";
         }
-        return new self($prefix.$host.$port);
+        return new self($prefix.$host.":".$port);
     }
 
     /**

--- a/PHPUnit/Extensions/Selenium2TestCase/URL.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/URL.php
@@ -76,10 +76,11 @@ final class PHPUnit_Extensions_Selenium2TestCase_URL
      */
     public static function fromHostAndPort($host, $port, $secure)
     {
-        if($secure) {
-            return new self("https://{$host}:{$port}");
+        $prefix = "http://";
+        if ($secure) {
+            $prefix = "https://";
         }
-        return new self("http://{$host}:{$port}");
+        return new self($prefix.$host.$port);
     }
 
     /**

--- a/PHPUnit/Extensions/Selenium2TestCase/URL.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/URL.php
@@ -71,10 +71,14 @@ final class PHPUnit_Extensions_Selenium2TestCase_URL
     /**
      * @param string $host
      * @param int port
+     * @param bool secure
      * @return PHPUnit_Extensions_Selenium2TestCase_URL
      */
-    public static function fromHostAndPort($host, $port)
+    public static function fromHostAndPort($host, $port, $secure)
     {
+        if($secure) {
+            return new self("https://{$host}:{$port}");
+        }
         return new self("http://{$host}:{$port}");
     }
 


### PR DESCRIPTION
The server url was resolved by concatenation in the `fromHostAndPort` method in [URL.php](https://github.com/giorgiosironi/phpunit-selenium/blob/master/PHPUnit/Extensions/Selenium2TestCase/URL.php). There was no way to create an https server url from host and port. Added a `secure` flag in the `parameters` which is passed to the method, and the URL is created accordingly.