### PR TITLE
Upgrade vagrant + travis + PHPUnit 8.x

### DIFF
--- a/.ci/common_env.sh
+++ b/.ci/common_env.sh
@@ -3,6 +3,6 @@
 SELENIUM_HUB_URL='http://127.0.0.1:4444'
 SELENIUM_JAR=/usr/share/selenium/selenium-server-standalone.jar
 SELENIUM_DOWNLOAD_URL=https://selenium-release.storage.googleapis.com/3.4/selenium-server-standalone-3.4.0.jar
-GECKODRIVER_DOWNLOAD_URL=https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+GECKODRIVER_DOWNLOAD_URL=https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
 GECKODRIVER_TAR=/tmp/geckodriver.tar.gz
 PHP_VERSION=$(php -v)

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ ! -f "/usr/local/bin/composer" ]; then
+if [ ! -x "$(command -v composer)" ]; then
     echo "Installing Composer"
     php -r "readfile('https://getcomposer.org/installer');" | sudo php -d apc.enable_cli=0 -- --install-dir=/usr/local/bin --filename=composer
 else
     echo "Updating Composer"
-    sudo /usr/local/bin/composer self-update
+    sudo composer self-update
 fi
 
 echo "Installing dependencies"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+sudo apt-get update
+
 if [ ! -x "$(command -v composer)" ]; then
     echo "Installing Composer"
     php -r "readfile('https://getcomposer.org/installer');" | sudo php -d apc.enable_cli=0 -- --install-dir=/usr/local/bin --filename=composer

--- a/.ci/vagrant_pre_setup.sh
+++ b/.ci/vagrant_pre_setup.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-sed -i "/mirror:\\/\\//d" /etc/apt/sources.list
-sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise main restricted universe multiverse" /etc/apt/sources.list
-sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates main restricted universe multiverse" /etc/apt/sources.list
-sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-backports main restricted universe multiverse" /etc/apt/sources.list
-sed -i "1ideb mirror://mirrors.ubuntu.com/mirrors.txt precise-security main restricted universe multiverse" /etc/apt/sources.list
-
-apt-get update
-
 apt-get install software-properties-common -y
 apt-get install python-software-properties -y
 
@@ -16,5 +8,5 @@ apt-add-repository ppa:ondrej/php -y
 apt-get update
 
 # installing xvfb, java and php
-apt-get install xvfb php5.6-cli php5.6-curl php5.6-xml php5.6-mbstring php-xdebug ncurses-term unzip xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic vim -y --no-install-recommends
+apt-get install xvfb php7.1-cli php7.1-curl php7.1-xml php7.1-mbstring php-xdebug ncurses-term unzip xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic vim -y --no-install-recommends
 

--- a/.ci/vagrant_pre_setup.sh
+++ b/.ci/vagrant_pre_setup.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-apt-get install software-properties-common -y
-apt-get install python-software-properties -y
-
 apt-add-repository ppa:ondrej/php -y
 
 apt-get update
+
+apt-get install software-properties-common -y
+apt-get install python-software-properties -y
 
 # installing xvfb, java and php
 apt-get install xvfb php7.1-cli php7.1-curl php7.1-xml php7.1-mbstring php-xdebug ncurses-term unzip xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic vim -y --no-install-recommends

--- a/.ci/vagrant_pre_setup.sh
+++ b/.ci/vagrant_pre_setup.sh
@@ -8,5 +8,5 @@ apt-get install software-properties-common -y
 apt-get install python-software-properties -y
 
 # installing xvfb, java and php
-apt-get install xvfb php7.1-cli php7.1-curl php7.1-xml php7.1-mbstring php-xdebug ncurses-term unzip xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic vim -y --no-install-recommends
+apt-get install xvfb php7.2-cli php7.2-curl php7.2-xml php7.2-mbstring php-xdebug ncurses-term unzip xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic vim -y --no-install-recommends
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: php
 dist: xenial
 php:
-  - 7
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 dist: xenial
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: xenial
 php:
   - 7
   - 7.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Use [Composer](https://getcomposer.org) and run `composer require --dev phpunit/
 Requirements
 ---
 
-Version `7.x` supports PHPUnit 7.x and is compatible with PHP 7.1+
+- Version `8.x` supports PHPUnit 8.x and is compatible with PHP 7.2+
+- Version `7.x` supports PHPUnit 7.x and is compatible with PHP 7.1+
 
 Older unsupported lines which will probably see no new releases:
 

--- a/Tests/Selenium2TestCaseTest.php
+++ b/Tests/Selenium2TestCaseTest.php
@@ -706,7 +706,7 @@ class Extensions_Selenium2TestCaseTest extends Tests_Selenium2TestCase_BaseTestC
         $this->byId('theTextbox')->value('t');
 
         $this->assertStringContainsString('{keydown(theTextbox - 84)}'
-                           . ' {keypress(theTextbox)}'
+                           . ' {keypress(theTextbox - 116)}'
                            . ' {keyup(theTextbox - 84)}',
                                $this->byId('eventlog')->value());
     }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ source ./.ci/start.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.cpus = 2

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/giorgiosironi/phpunit-selenium/issues",
+        "issues": "https://github.com/giorgiosironi/phpunit-selenium/issues"
     },
     "require": {
         "php": ">=7.1",

--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,9 @@
         "issues": "https://github.com/giorgiosironi/phpunit-selenium/issues"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-curl": "*",
-        "phpunit/phpunit": ">=7.0,<8.0"
+        "phpunit/phpunit": ">=8.0,<9.0"
     },
     "require-dev": {
        "phing/phing": "2.*"


### PR DESCRIPTION
Hello,
i wanted help you with upgrade to PHPUnit 8.0, but env is very old and doesn't work. This PR should fix it.

This PR upgrade vagrant box and some stuff around:
 
- fix format composer.json
- upgraded vagrant box version (upgraded to ubuntu/xenial64)
- upgraded geckodriver (due to never firefox version)
- upgraded php packages to version 7.1
- fix test (probably due to never firefox version)
- fix travis (build 7.1, 7.2, 7.3, 7.4)

Thank you