### PR TITLE
Get all cookies

### DIFF
--- a/PHPUnit/Extensions/Selenium2TestCase/Session/Cookie.php
+++ b/PHPUnit/Extensions/Selenium2TestCase/Session/Cookie.php
@@ -96,6 +96,23 @@ class Cookie
     }
 
     /**
+     * Return all cookies
+     *
+     * @return array [name => value]
+     */
+    public function getAll()
+    {
+        $result = [];
+
+        $cookies = $this->driver->curl('GET', $this->url)->getValue();
+        foreach ($cookies as $cookie) {
+            $result[$cookie['name']] = $cookie['value'];
+        }
+
+        return $result;
+    }
+
+    /**
      * @param string $name
      * @return void
      */

--- a/Tests/Selenium2TestCase/Coverage/CookieTest.php
+++ b/Tests/Selenium2TestCase/Coverage/CookieTest.php
@@ -43,4 +43,14 @@ class Tests_Selenium2TestCase_Coverage_CookieTest extends Tests_Selenium2TestCas
         $this->url('/');
         $this->assertNotEquals($this->getTestIdCookie(), $previousTestIdCookie);
     }
+
+    public function testGetAll()
+    {
+        $cookies = $this->prepareSession()->cookie()->getAll();
+
+        $this->assertIsArray($cookies);
+        $this->assertCount(1, $cookies);
+        $this->assertArrayHasKey('PHPUNIT_SELENIUM_TEST_ID', $cookies);
+        $this->assertEquals($this->getTestId(), $cookies['PHPUNIT_SELENIUM_TEST_ID']);
+    }
 }


### PR DESCRIPTION
Added a method to get all cookies in the `[name => value]` format.

We wanted to write a Selenium test which would check if there is a certain number of cookies set and check their names/values because of the European GDPR law.