### PR TITLE
Fix phpunit method filter when multiple browsers are used

### DIFF
--- a/PHPUnit/Extensions/SeleniumTestSuite.php
+++ b/PHPUnit/Extensions/SeleniumTestSuite.php
@@ -147,6 +147,10 @@ class SeleniumTestSuite extends TestSuite
             foreach ($browsers as $browser) {
                 $browserSuite = SeleniumBrowserSuite::fromClassAndBrowser($className, $browser);
                 foreach ($class->getMethods() as $method) {
+                    if (!TestUtil::isTestMethod($method)) {
+                        continue;
+                    }
+
                     $browserSuite->addTestMethod($class, $method);
                 }
                 $browserSuite->setupSpecificBrowser($browser);
@@ -158,10 +162,6 @@ class SeleniumTestSuite extends TestSuite
             // Create tests from test methods for single browser.
             foreach ($class->getMethods() as $method) {
                 if (!TestUtil::isTestMethod($method)) {
-                    continue;
-                }
-
-                if (!$method->isPublic()) {
                     continue;
                 }
 


### PR DESCRIPTION
This PR is a followup of https://github.com/giorgiosironi/phpunit-selenium/pull/449
The original PR fixed the method filter when only a single browser is being tested.
This PR adds a similar fix when multiple browsers are being tested.
Also, the test for $method->isPublic() has been removed, since TestUtil::isTestMethod() already checks if the method is public.

Fixes #453
Fixes #454